### PR TITLE
make compatible with elm 0.19.1

### DIFF
--- a/src/loadElmStories.tsx
+++ b/src/loadElmStories.tsx
@@ -24,24 +24,21 @@ loadElmStories("Text (Elm)", module, require("./TextStories.elm"), [
 */
 interface Ports {
   [key: string]: {
-    subscribe: () => void,
+    subscribe: () => void
     send: () => void
   }
 }
 export const loadElmStories = (
   name: string,
   module: NodeModule,
-  elmApp: { Elm: { Main: any } },
+  elmApp: any,
   storyNames: string[],
   ports?: (ports: Ports) => void
 ) => {
-  if (!elmApp.Elm.Main) {
-    throw new Error("Elm storybook module did not exist with name `Main`")
-  }
   const stories = storiesOf(name, module)
   for (const storyName of storyNames) {
     stories.add(storyName, () => (
-      <ElmComponent src={elmApp.Elm.Main} flags={storyName} ports={ports} />
+      <ElmComponent src={elmApp} flags={storyName} ports={ports} />
     ))
   }
 }


### PR DESCRIPTION
With Elm 0.19.0, the compiler did not force the main Elm module to have the same name as the file on disk.

Eg, you could do 
`module Main exposing (main)`, but put this a file `ButtonStories.elm`

The Elm 0.19.1 compiler will not allow this to compile. 

Therefore, we can no longer assume the module name will be `Main` when upgrading to Elm 0.19.1