### PR TITLE
remove css wrapper styles

### DIFF
--- a/src/ElmStorybook.elm
+++ b/src/ElmStorybook.elm
@@ -91,9 +91,7 @@ storybook stories =
         storybookView model =
             case ( model.currentStory, model.customModel ) of
                 ( Just currentStory, Just customModel ) ->
-                    div [ style "width" "100vw", style "display" "flex", style "justify-content" "center" ]
-                        [ currentStory.view customModel
-                        ]
+                    currentStory.view customModel
 
                 ( _, _ ) ->
                     text ("Story " ++ model.currentStoryName ++ " not found")


### PR DESCRIPTION
The wrapper styles are well meaning, but often cause unexpected side effects such as divs that are 0px wide instead of filling the available space. I don't think they belong in this plugin.